### PR TITLE
fix:removed extra blank spaces between sections

### DIFF
--- a/src/Index.html
+++ b/src/Index.html
@@ -132,8 +132,6 @@
           </div>
         </div>
       </div>
-
-
       <div class="purchase text-center">
         <h1>Purchase Whatever You Want</h1>
         <p>


### PR DESCRIPTION
I just observed some insistence in index.html, it has two blank spaces between container fluid div class and purchase div class. I hope you will like it.